### PR TITLE
Fix: Move public enums to their own files

### DIFF
--- a/backend/src/main/java/com/MC_656/mobility/model/Vehicle.java
+++ b/backend/src/main/java/com/MC_656/mobility/model/Vehicle.java
@@ -16,23 +16,14 @@ import jakarta.validation.constraints.Size;
 
 import java.util.Objects;
 
-// Updated to include only eco-friendly options
-public enum VehicleType { // Made public
-    BICYCLE,      // Traditional bicycle
-    E_BIKE,       // Electric bicycle
-    SCOOTER,      // Kick scooter or electric scooter not requiring license
-    E_SCOOTER,    // Electric scooter (potentially more powerful, moped-like)
-    ELECTRIC_CAR, // Fully electric car
-    CARGO_BIKE    // Bicycle designed for transporting larger items
-    // Add other eco-friendly types as needed, e.g., E_MOTORCYCLE
-}
-
-public enum VehicleStatus { // Made public
-    AVAILABLE,
-    RENTED,
-    MAINTENANCE,
-    UNAVAILABLE
-}
+// VehicleType and VehicleStatus enums are now in their own files.
+// Imports for them are not strictly needed if they are in the same package,
+// but would be if they were in different packages.
+// For clarity, if they were in a sub-package like com.MC_656.mobility.model.enums,
+// you'd add:
+// import com.MC_656.mobility.model.enums.VehicleType;
+// import com.MC_656.mobility.model.enums.VehicleStatus;
+// Since they are in com.MC_656.mobility.model directly, no import is needed here.
 
 @Entity
 @Table(name = "vehicles")

--- a/backend/src/main/java/com/MC_656/mobility/model/VehicleStatus.java
+++ b/backend/src/main/java/com/MC_656/mobility/model/VehicleStatus.java
@@ -1,0 +1,8 @@
+package com.MC_656.mobility.model;
+
+public enum VehicleStatus {
+    AVAILABLE,
+    RENTED,
+    MAINTENANCE,
+    UNAVAILABLE
+}

--- a/backend/src/main/java/com/MC_656/mobility/model/VehicleType.java
+++ b/backend/src/main/java/com/MC_656/mobility/model/VehicleType.java
@@ -1,0 +1,11 @@
+package com.MC_656.mobility.model;
+
+public enum VehicleType {
+    BICYCLE,      // Traditional bicycle
+    E_BIKE,       // Electric bicycle
+    SCOOTER,      // Kick scooter or electric scooter not requiring license
+    E_SCOOTER,    // Electric scooter (potentially more powerful, moped-like)
+    ELECTRIC_CAR, // Fully electric car
+    CARGO_BIKE    // Bicycle designed for transporting larger items
+    // Add other eco-friendly types as needed, e.g., E_MOTORCYCLE
+}


### PR DESCRIPTION
- Moved public enums VehicleType and VehicleStatus from Vehicle.java to their own dedicated files (VehicleType.java and VehicleStatus.java) to comply with Java's public type declaration rules.
- This addresses compilation errors related to public types not being in their own files.